### PR TITLE
BTRSplitView

### DIFF
--- a/Butter.xcodeproj/project.pbxproj
+++ b/Butter.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		03FA6F6C16743D6000491A1D /* BTRCollectionViewLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 03FA6F5C16743D6000491A1D /* BTRCollectionViewLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		03FA6F6D16743D6000491A1D /* BTRCollectionViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 03FA6F5D16743D6000491A1D /* BTRCollectionViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		03FA6F6E16743D6000491A1D /* BTRCollectionViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 03FA6F5E16743D6000491A1D /* BTRCollectionViewCell.m */; };
+		844FFF8A16823D4800B67ECC /* BTRSplitView.h in Headers */ = {isa = PBXBuildFile; fileRef = 844FFF8816823D4800B67ECC /* BTRSplitView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		844FFF8B16823D4800B67ECC /* BTRSplitView.m in Sources */ = {isa = PBXBuildFile; fileRef = 844FFF8916823D4800B67ECC /* BTRSplitView.m */; };
 		ABAB86DE167EEEEC003DC0CD /* BTRCollectionViewListLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = ABAB86DC167EEEEC003DC0CD /* BTRCollectionViewListLayout.h */; };
 		ABAB86DF167EEEEC003DC0CD /* BTRCollectionViewListLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = ABAB86DD167EEEEC003DC0CD /* BTRCollectionViewListLayout.m */; };
 		ABACCA3E167AD439003EFDD6 /* NSView+BTRAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = ABACCA36167AD439003EFDD6 /* NSView+BTRAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -113,6 +115,8 @@
 		03FA6F5E16743D6000491A1D /* BTRCollectionViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BTRCollectionViewCell.m; path = Butter/BTRCollectionView/BTRCollectionViewCell.m; sourceTree = SOURCE_ROOT; };
 		03FA702916746A7900491A1D /* CircleLayout.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = CircleLayout.xcodeproj; path = Butter/Examples/BTRCollectionView/CircleLayout/CircleLayout.xcodeproj; sourceTree = "<group>"; };
 		03FA703316746A7F00491A1D /* BasicExample.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = BasicExample.xcodeproj; path = Butter/Examples/BTRCollectionView/BasicExample/BasicExample.xcodeproj; sourceTree = "<group>"; };
+		844FFF8816823D4800B67ECC /* BTRSplitView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BTRSplitView.h; path = BTRSplitView/BTRSplitView.h; sourceTree = "<group>"; };
+		844FFF8916823D4800B67ECC /* BTRSplitView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BTRSplitView.m; path = BTRSplitView/BTRSplitView.m; sourceTree = "<group>"; };
 		ABAB86DC167EEEEC003DC0CD /* BTRCollectionViewListLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BTRCollectionViewListLayout.h; path = Butter/BTRCollectionView/BTRCollectionViewListLayout.h; sourceTree = SOURCE_ROOT; };
 		ABAB86DD167EEEEC003DC0CD /* BTRCollectionViewListLayout.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BTRCollectionViewListLayout.m; path = Butter/BTRCollectionView/BTRCollectionViewListLayout.m; sourceTree = SOURCE_ROOT; };
 		ABACCA36167AD439003EFDD6 /* NSView+BTRAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSView+BTRAdditions.h"; path = "Extensions/NSView+BTRAdditions.h"; sourceTree = "<group>"; };
@@ -207,6 +211,7 @@
 			isa = PBXGroup;
 			children = (
 				ABACCA35167AD439003EFDD6 /* Extensions */,
+				844FFF8316823D2400B67ECC /* BTRSplitView */,
 				ABE93937167993DB00A7A1B8 /* BTRImageView */,
 				AB05CE1A1672E95900534E63 /* BTRCollectionView */,
 				ABB9D73D167BD6C800ECB31D /* BTRControl */,
@@ -260,6 +265,15 @@
 				03FA703C16746A7F00491A1D /* BasicExample.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		844FFF8316823D2400B67ECC /* BTRSplitView */ = {
+			isa = PBXGroup;
+			children = (
+				844FFF8816823D4800B67ECC /* BTRSplitView.h */,
+				844FFF8916823D4800B67ECC /* BTRSplitView.m */,
+			);
+			name = BTRSplitView;
 			sourceTree = "<group>";
 		};
 		AB05CE1A1672E95900534E63 /* BTRCollectionView */ = {
@@ -359,6 +373,7 @@
 				ABACCA40167AD439003EFDD6 /* BTRClipView.h in Headers */,
 				ABACCA42167AD439003EFDD6 /* BTRScrollView.h in Headers */,
 				ABACCA44167AD439003EFDD6 /* BTRView.h in Headers */,
+				844FFF8A16823D4800B67ECC /* BTRSplitView.h in Headers */,
 				03E41481167B03DB00EACE0F /* BTRCommon.h in Headers */,
 				ABB9D743167BD73A00ECB31D /* BTRControl.h in Headers */,
 				ABAB86DE167EEEEC003DC0CD /* BTRCollectionViewListLayout.h in Headers */,
@@ -492,6 +507,7 @@
 				ABACCA45167AD439003EFDD6 /* BTRView.m in Sources */,
 				ABB9D744167BD73A00ECB31D /* BTRControl.m in Sources */,
 				ABAB86DF167EEEEC003DC0CD /* BTRCollectionViewListLayout.m in Sources */,
+				844FFF8B16823D4800B67ECC /* BTRSplitView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Butter/BTRSplitView/BTRSplitView.h
+++ b/Butter/BTRSplitView/BTRSplitView.h
@@ -1,0 +1,58 @@
+//
+//  BTRSplitView.h
+//  BTRSplitViewDemo
+//
+//  Created by Robert Widmann on 12/8/12.
+//  Copyright (c) 2012 CodaFi. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+typedef void(^BTRSplitViewDrawDividerBlock)(CGRect rect, NSUInteger index);
+
+@interface BTRSplitView : NSSplitView
+
+/** @name Drawing A SplitView */
+
+/**
+ @param rect The rectangle specifying the region that needs redrawing within the divider.
+ @param index The index of the divider being redrawn.
+ @discussion Because we cannot override -dividerColor for index-based drawing,
+	this is the next step up.  While it may be overkill to add an entire
+	drawing block just for dividers, it's something that NSSplitView should have had
+	from the get-go (or at least some way to draw with the index of the divider, not just the frame.
+	Suffice to say there is some black-magic involved in getting a subview index for the block...
+ */
+
+@property (nonatomic, copy) BTRSplitViewDrawDividerBlock dividerDrawBlock;
+
+/** @name Positioning the Panes of a Split View */
+
+/**
+ Returns the position of the divider at a given index
+ @param dividerIndex The index of the divider that will be queried for it's position.
+ @return The position of the divider, or 0 if an invalid index was specified or the subview is collapsed.
+ */
+- (CGFloat)positionOfDividerAtIndex:(NSInteger)dividerIndex;
+
+
+/**
+ Defaults to NSSplitView's interpretation, sans animation.
+ @param position The ending position of the divider that will be moved.
+ @param dividerIndex The index of the divider that will be moved.
+ */
+- (void)setPosition:(CGFloat)position ofDividerAtIndex:(NSInteger)dividerIndex;
+
+/**
+ Sets the position of the divider at the given index with or without animation.
+ @param position The ending position of the divider that will be moved.
+ @param dividerIndex The index of the divider that will be moved.
+ @param withAnimation Specify this to have the divider animate for the default duration (0.25 sec.), else default to NSSplitView's interpretation
+ @discussion Whether animation is applied or not, the frames of the views themselves are adjusted,
+ meaning that we get consistent redraw behavior, and smooth collapsing because BTRSplitView defaults to having
+ a Core Animation layer.  Resize is subject to the constraints outlined in your delegate, so animation reserves the
+ right to adjust the frames of adjacent subviews to ensure the position request is satisfied.
+ */
+- (void)setPosition:(CGFloat)position ofDividerAtIndex:(NSInteger)dividerIndex withAnimation:(BOOL)animate;
+
+@end

--- a/Butter/BTRSplitView/BTRSplitView.m
+++ b/Butter/BTRSplitView/BTRSplitView.m
@@ -1,0 +1,149 @@
+//
+//  BTRSplitView.m
+//  BTRSplitViewDemo
+//
+//  Created by Robert Widmann on 12/8/12.
+//  Copyright (c) 2012 CodaFi. All rights reserved.
+//
+
+#import "BTRSplitView.h"
+
+static CGFloat const kBTRSplitViewAnimationDuration = .25;
+
+@implementation BTRSplitView
+
+//We REEEALLY want dat layer.
+- (id)init {
+	self = [super init];
+	if (self == nil) return nil;
+	self.wantsLayer = YES;
+    return self;
+}
+
+- (id)initWithFrame:(NSRect)frame
+{
+    self = [super initWithFrame:frame];
+	if (self == nil) return nil;
+	self.wantsLayer = YES;
+    return self;
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder {
+	self = [super initWithCoder:aDecoder];
+    if (self == nil) return nil;
+	self.wantsLayer = YES;
+    return self;
+}
+
+#pragma mark - Drawing
+
+-(void)drawDividerInRect:(NSRect)rect {
+	if (self.dividerDrawBlock) {
+		self.dividerDrawBlock(rect, [self _dividerIndexFromRect:rect]);
+	} else {
+		[super drawDividerInRect:rect];
+	}
+}
+
+- (void)drawRect:(NSRect)dirtyRect
+{
+    //Don't interfere with NSSplitView's drawRect.
+	//It's sad to have to do it, but it appears that NSSplitView's
+	//layer doesn't redraw properly without a subview adjustion...
+	//*le sigh*.
+	[self adjustSubviews];
+	[super drawRect:dirtyRect];
+}
+
+#pragma mark - Position
+
+-(void)setPosition:(CGFloat)position ofDividerAtIndex:(NSInteger)dividerIndex {
+	[self setPosition:position ofDividerAtIndex:dividerIndex withAnimation:NO];
+}
+
+- (void)setPosition:(CGFloat)endValue ofDividerAtIndex:(NSInteger)dividerIndex withAnimation:(BOOL)animate
+{
+	//No animation, no problem!
+    if (!animate) {
+        [super setPosition:endValue ofDividerAtIndex:dividerIndex];
+    }
+    else {
+		//Imply that the subview we want to animate is also the index of the divider we want to animate
+		//Considering dividers are always (subviews-1), we don't have to subtract that one ourselves.
+		//We can also ssume that the starting value if the width of said subview
+		NSView *resizingSubview = [self.subviews objectAtIndex:dividerIndex];
+		CGFloat startValue = NSWidth(resizingSubview.frame);
+		NSRect currentFrame, startingFrame, endingFrame;
+		currentFrame = [resizingSubview frame];
+		
+		//If the subview is hidden (i.e. collapsed), unhide it so NSAnimation doesn't go completely bonkers
+		[resizingSubview setHidden:NO];
+		
+		if ([self isVertical]) {
+			startingFrame = (NSRect){currentFrame.origin, NSMakeSize(startValue, currentFrame.size.height)};
+			endingFrame = (NSRect){currentFrame.origin, NSMakeSize(endValue, currentFrame.size.height)};
+		} else {
+			startingFrame = (NSRect){currentFrame.origin, NSMakeSize(currentFrame.size.width, startValue)};
+			endingFrame = (NSRect){currentFrame.origin, NSMakeSize(currentFrame.size.width, endValue)};
+		}
+		
+		//Because of our Core Animation backing layer, this should use Core Animation... theoretically.
+		[NSAnimationContext beginGrouping];
+		[[NSAnimationContext currentContext] setDuration:kBTRSplitViewAnimationDuration];
+		[[NSAnimationContext currentContext]setCompletionHandler:^{
+			if (endValue == 0) {
+				//If the end value is zero, we're gonna go ahead and assume a collapse, which
+				//means hiding the subview
+				[resizingSubview setHidden:YES];
+			}
+		}];
+		[[resizingSubview animator] setFrame: endingFrame];
+		[NSAnimationContext endGrouping];
+    }
+}
+
+//OMG, finally NSSplitView has a way to get the position of the divider at a given index
+- (CGFloat)positionOfDividerAtIndex:(NSInteger)dividerIndex
+{
+	if(dividerIndex > [[self subviews] count]){
+		return 0;
+	}
+	
+	NSView *subview = (NSView *)[[self subviews] objectAtIndex:dividerIndex];
+	NSRect frame = [subview frame];
+	
+	if(self.isVertical) {
+		return frame.origin.x + frame.size.width;
+	} else {
+		return frame.origin.y + frame.size.height;
+	}
+}
+
+#pragma mark - Private
+
+//This is gonna be a little crazy...
+-(NSInteger)_dividerIndexFromRect:(NSRect)rect {
+	//Set result equal to zero to start...
+	NSInteger result = 0;
+	if (self.subviews.count == 2) {
+		return result; //So we can return 0 if there are only two subviews (Logic).  
+	}
+	//Adjust the passed in rect by it's divider thickness so we can try to ping
+	//the subview adjacent to it.  (either to the left, or above it).
+	NSRect adjustedRect = rect;
+	if (self.isVertical) {
+		adjustedRect.origin.x -= 1; //Left one pixel
+	} else {
+		adjustedRect.origin.y += self.dividerThickness + 1; //Up the divider's thickness plus some padding
+	}
+	//Loop through our subviews to get the index of the view adjacent to the divider.
+	for (int i = 0; i < self.subviews.count; i++) {
+		NSView *subview = [self.subviews objectAtIndex:i];
+		if (!CGRectIntersectsRect(subview.frame, adjustedRect)) continue;
+		result = i;
+	}
+	return result;
+}
+
+
+@end

--- a/Butter/Butter.h
+++ b/Butter/Butter.h
@@ -12,3 +12,4 @@
 #import <Butter/BTRCollectionViewFlowLayout.h>
 #import <Butter/BTRImageView.h>
 #import <Butter/BTRControl.h>
+#import <Butter/BTRSplitView.h>


### PR DESCRIPTION
Because NSSplitView sucks.  Come on, we all know it:  
- Cringe-worthy delegate methods.
- An (almost intentional) aversion to animation.
- Positioning nightmares

BTRSplitView aims to solve the last two (if only because overriding delegate methods would be taking too much control into our own hands) with a subview drawing block, and methods to set and get the position of subviews easily, and in the case of setting, with animation.
