### PR TITLE
BTRScrollView content & indicator insets basic support

### DIFF
--- a/Butter/Extensions/BTRClipView.h
+++ b/Butter/Extensions/BTRClipView.h
@@ -42,4 +42,7 @@
 // Defaults to 0.78.
 @property (nonatomic, assign) CGFloat decelerationRate;
 
+// Insets applied to the content.
+@property (assign) NSEdgeInsets contentInsets;
+
 @end

--- a/Butter/Extensions/BTRClipView.m
+++ b/Butter/Extensions/BTRClipView.m
@@ -144,6 +144,36 @@ static CVReturn BTRScrollingCallback(CVDisplayLinkRef displayLink, const CVTimeS
 	}
 }
 
+- (NSPoint)constrainScrollPoint:(NSPoint)newOrigin
+{
+    NSRect documentRect = [self documentRect];
+    if (newOrigin.y < NSMinY(documentRect)) {
+        newOrigin.y = NSMinY(documentRect);
+    }
+    CGFloat bottomY = newOrigin.y + NSHeight(self.bounds);
+    if (bottomY > NSMaxY(documentRect)) {
+        bottomY = NSMaxY(documentRect);
+        newOrigin.y = bottomY - NSHeight(self.bounds);
+    }
+    return newOrigin;
+}
+
+- (NSRect)documentRect
+{
+    NSRect r = [super documentRect];
+    r.origin.y -= self.contentInsets.top;
+    r.size.height += self.contentInsets.top + self.contentInsets.bottom;
+    return r;
+}
+
+- (NSRect)documentVisibleRect
+{
+    NSRect r = [super documentVisibleRect];
+    r.origin.y -= self.contentInsets.top;
+    r.size.height += self.contentInsets.top + self.contentInsets.bottom;
+    return r;
+}
+
 - (void)setDestinationOrigin:(CGPoint)origin {
 	// We want to round up to the nearest integral point, since some classes
 	// seem to provide non-integral point values.

--- a/Butter/Extensions/BTRScrollView.h
+++ b/Butter/Extensions/BTRScrollView.h
@@ -17,4 +17,13 @@
 // Overridden by subviews to change the class of the clip view
 + (Class)clipViewClass;
 
+// The distance that the content view is inset from the enclosing scroll view.
+@property (nonatomic, assign) NSEdgeInsets contentInsets;
+
+// The distance the scroll indicators are inset from the edge of the scroll view.
+@property (nonatomic, assign) NSEdgeInsets scrollIndicatorInsets;
+
+// The point at which the origin of the content view is offset from the origin of the scroll view.
+@property (nonatomic, assign) NSPoint contentOffset;
+
 @end

--- a/Butter/Extensions/BTRScrollView.m
+++ b/Butter/Extensions/BTRScrollView.m
@@ -8,8 +8,10 @@
 
 #import "BTRScrollView.h"
 #import "BTRClipView.h"
+#import <QuartzCore/CoreAnimation.h>
 
 @implementation BTRScrollView
+@synthesize contentInsets = _contentInsets;
 
 #pragma mark Lifecycle
 
@@ -40,10 +42,86 @@
 	clipView.backgroundColor = [self.contentView backgroundColor];
 	self.contentView = clipView;
 	self.documentView = documentView;
+    clipView.contentInsets = self.contentInsets;
 }
 
 + (Class)clipViewClass {
 	return [BTRClipView class];
+}
+
+- (BTRClipView *)scrollClipView
+{
+    if ([self.contentView isKindOfClass:[BTRClipView class]]) {
+        return (BTRClipView *)self.contentView;
+    }
+    return nil;
+}
+
+- (void)setContentInsets:(NSEdgeInsets)contentInsets
+{
+    NSPoint oldScrollPoint = self.contentOffset;
+
+    [[self scrollClipView] setContentInsets:contentInsets];
+    [self reflectScrolledClipView:[self scrollClipView]];
+
+    self.contentOffset = NSMakePoint(oldScrollPoint.x, oldScrollPoint.y - contentInsets.top);
+    _contentInsets = contentInsets;
+}
+
+- (void)setScrollIndicatorInsets:(NSEdgeInsets)scrollIndicatorInsets
+{
+    _scrollIndicatorInsets = scrollIndicatorInsets;
+    [self setNeedsLayout:YES];
+}
+
+- (void)tile
+{
+    [super tile];
+
+    NSRect verticalScrollerFrame = self.verticalScroller.frame;
+    verticalScrollerFrame.origin.y += self.scrollIndicatorInsets.top;
+    verticalScrollerFrame.size.height -= self.scrollIndicatorInsets.top + self.scrollIndicatorInsets.bottom;
+    verticalScrollerFrame.origin.x -= self.scrollIndicatorInsets.right;
+    self.verticalScroller.frame = verticalScrollerFrame;
+
+    NSRect horizontalScrollerFrame = self.horizontalScroller.frame;
+    horizontalScrollerFrame.origin.x += self.scrollIndicatorInsets.left;
+    horizontalScrollerFrame.size.width -= self.scrollIndicatorInsets.left + self.scrollIndicatorInsets.right;
+    horizontalScrollerFrame.origin.y -= self.scrollIndicatorInsets.bottom;
+    self.horizontalScroller.frame = horizontalScrollerFrame;
+}
+
+- (void)resizeSubviewsWithOldSize:(NSSize)oldSize
+{
+    NSSize currentSize = self.frame.size;
+
+    NSPoint oldScrollPoint = self.contentOffset;
+
+    [super resizeSubviewsWithOldSize:oldSize];
+
+    if (NSEqualSizes(oldSize, currentSize) == NO) {
+        self.contentOffset = oldScrollPoint;
+    }
+}
+
+- (NSPoint)contentOffset
+{
+    return self.contentView.bounds.origin;
+}
+
+- (void)setContentOffset:(NSPoint)contentOffset
+{
+    [self.contentView setBoundsOrigin:contentOffset];
+}
+
+- (id)animationForKey:(NSString *)key
+{
+    if ([key isEqualToString:@"contentOffset"]) {
+        CABasicAnimation *animation = [CABasicAnimation animation];
+        return animation;
+    }
+
+    return [super animationForKey:key];
 }
 
 @end


### PR DESCRIPTION
"Hey guys, I'm looking at what Jack was talking about."
This is basic support for `scrollIndicatorInsets` and `contentInsets` for `BTRScrollView` (like in `UIScrollView`). I did it for my private project, but unfortunately there is one issue that I cannot resolve, so maybe you could help with it: if you scroll to the top so you see top inset, and resize window, scrollview resets `contentOffset` to 0 by Y, so inset is not visible anymore. 
You should try, just set `contentInsets` to something with positive `top`, scroll to top and resize window.
Thanks!
