### PR TITLE
Ignore mouse events when BTRControl enabled == NO

### DIFF
--- a/Butter/BTRControl.m
+++ b/Butter/BTRControl.m
@@ -296,7 +296,7 @@
 }
 
 - (void)mouseUp:(NSEvent *)event {
-	if (self.shouldHandleEvents) {
+	if (self.userInteractionEnabled) {
 		[self handleMouseUp:event];
 	} else {
 		[super mouseUp:event];
@@ -304,7 +304,7 @@
 }
 
 - (void)rightMouseUp:(NSEvent *)event {
-	if (self.shouldHandleEvents) {
+	if (self.userInteractionEnabled) {
 		[self handleMouseUp:event];
 	} else {
 		[super rightMouseUp:event];


### PR DESCRIPTION
This fixes some funky behaviour like the highlighted state showing when the button is clicked while `enabled` == `NO`.
