### PR TITLE
Normalize the import of other Butter headers in Butter headers

### DIFF
--- a/Butter/BTRActivityIndicator.h
+++ b/Butter/BTRActivityIndicator.h
@@ -12,7 +12,7 @@ typedef NS_ENUM(NSInteger, BTRActivityIndicatorStyle) {
     BTRActivityIndicatorStyleGray
 };
 
-#import <Butter/Butter.h>
+#import "BTRView.h"
 
 // An indeterminate activity indicator.
 @interface BTRActivityIndicator : BTRView

--- a/Butter/BTRControl.h
+++ b/Butter/BTRControl.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 ButterKit. All rights reserved.
 
 // This class is heavily inspired by UIKit and TwUI.
-#import <Butter/BTRView.h>
+#import "BTRView.h"
 
 typedef NS_OPTIONS(NSUInteger, BTRControlEvents) {
 	// TODO: UNIMPLEMENTED

--- a/Butter/BTRImageView.h
+++ b/Butter/BTRImageView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 ButterKit. All rights reserved.
 //
 
-#import <Butter/BTRView.h>
+#import "BTRView.h"
 
 // Equivalent to UIViewContentMode. See "Providing CALayer Content"
 // in the Core Animation guide for more information about the modes.

--- a/Butter/BTRPopUpButton.h
+++ b/Butter/BTRPopUpButton.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 ButterKit. All rights reserved.
 //
 
-#import <Butter/Butter.h>
+#import "BTRControl.h"
 
 @interface BTRPopUpButton : BTRControl
 


### PR DESCRIPTION
In some places `#import <Butter/BTRView.h>` was used while others used `#import "BTRView.h"` I chose to change all of them to be the latter as that was the most common form. This also makes it easier to just use parts of the framework (if one does not want certain parts :open_mouth:).
