### PR TITLE
Fix build when prefix header is disabled.

### DIFF
--- a/Butter/BTRActivityIndicator.h
+++ b/Butter/BTRActivityIndicator.h
@@ -7,12 +7,12 @@
 //
 //	Much thanks to David Rönnqvist (@davidronnqvist) for the original idea of using CAReplicatorLayer.
 
+#import "BTRView.h"
+
 typedef NS_ENUM(NSInteger, BTRActivityIndicatorStyle) {
     BTRActivityIndicatorStyleWhite,
     BTRActivityIndicatorStyleGray
 };
-
-#import "BTRView.h"
 
 // An indeterminate activity indicator.
 @interface BTRActivityIndicator : BTRView


### PR DESCRIPTION
I found out the hard way that `BTRActivityIndicator` doesn’t compile when prefix headers are disabled in favor of Objective-C modules. I relocated one `#import` in `BTRActivityIndicator.h` so that it compiles correctly under such circumstances.
